### PR TITLE
fix error caused by giphy url call number limit < 30

### DIFF
--- a/js/logic.js
+++ b/js/logic.js
@@ -14,7 +14,7 @@ var logicObj = {
   },
 
   makeGiphyUrl: function() {
-    var urlBase = "https://api.giphy.com/v1/gifs/search?api_key=03d284987c9444e8931acbc0601067d3&limit=25&offset=0&rating=G&lang=en&q=";
+    var urlBase = "https://api.giphy.com/v1/gifs/search?api_key=03d284987c9444e8931acbc0601067d3&limit=30&offset=0&rating=G&lang=en&q=";
     var searchTerm = severityGifMap[logicObj.resultsObj.status];
     return urlBase + searchTerm;
   },


### PR DESCRIPTION
Fixed error appearing in console. Cause was rate limit on giphy api call set to 25, but giphy url randomiser was between 0 - 30. Fixed by changing giphy url rate limit to 30.

#41 